### PR TITLE
Match ckan filestore logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+
+subdir/
+*.idea

--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,11 @@ Optional::
     # To change the acl of the uploaded file. Default is public-read.
     ckanext.s3filestore.acl = private
 
+    # To use user provided filepath and not use internal url basename on download
+    # Set to False to be backwards compatible to ckan file store, set to True if already using s3plugin
+    # If False /dataset/{id}/resource/{resource_id}/orig_download/{filename} will be available
+    ckanext.s3filestore.use_filename = True
+
 
 ------------------------
 Development Installation

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -11,6 +11,7 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IUploader)
     plugins.implements(plugins.IRoutes, inherit=True)
 
+
     # IConfigurer
 
     def update_config(self, config_):
@@ -44,7 +45,6 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
             ckanext.s3filestore.uploader.BaseS3Uploader().get_s3_bucket(
                 config.get('ckanext.s3filestore.aws_bucket_name'))
 
-        self.use_filename = toolkit.asbool(config.get('ckanext.s3filestore.use_filename', False))
 
     # IUploader
 
@@ -71,7 +71,8 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
                           '/dataset/{id}/resource/{resource_id}/download/{filename}',
                           action='resource_download')
             #Allow fallback to access old files
-            if not self.use_filename:
+            use_filename = toolkit.asbool(toolkit.config.get('ckanext.s3filestore.use_filename', False))
+            if not use_filename:
                 m.connect('resource_download',
                           '/dataset/{id}/resource/{resource_id}/orig_download/{filename}',
                           action='resource_download')

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -44,6 +44,8 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
             ckanext.s3filestore.uploader.BaseS3Uploader().get_s3_bucket(
                 config.get('ckanext.s3filestore.aws_bucket_name'))
 
+        self.use_filename = toolkit.asbool(config.get('ckanext.s3filestore.use_filename', False))
+
     # IUploader
 
     def get_resource_uploader(self, data_dict):
@@ -67,6 +69,11 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
                           action='resource_download')
                 m.connect('resource_download',
                           '/dataset/{id}/resource/{resource_id}/download/{filename}',
+                          action='resource_download')
+            #Allow fallback to access old files
+            if not self.use_filename:
+                m.connect('resource_download',
+                          '/dataset/{id}/resource/{resource_id}/orig_download/{filename}',
                           action='resource_download')
 
             # fallback controller action to download from the filesystem

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -369,6 +369,7 @@ class S3ResourceUploader(BaseS3Uploader):
 
         super(S3ResourceUploader, self).__init__()
 
+        self.use_filename = toolkit.asbool(config.get('ckanext.s3filestore.use_filename', False))
         path = config.get('ckanext.s3filestore.aws_storage_path', '')
         self.storage_path = os.path.join(path, 'resources')
         self.filename = None
@@ -463,8 +464,7 @@ class S3ResourceUploader(BaseS3Uploader):
         downloading the uploaded file from S3.
         '''
 
-
-        if filename is None:
+        if not self.use_filename or filename is None:
             filename = os.path.basename(self.url)
         filename = munge.munge_filename(filename)
         key_path = self.get_path(id, filename)


### PR DESCRIPTION
ckan file store logic does not care about the filename provided by the user, it also stores
files without filenames nor filetype but as a uuid string in a resource folder.

S3 Plugin was built to store in a resource folder and the filename was used
If not provided it crashed, which was recently corrected.
Only problem is that people who use ckan have gotten use to being able to change
filenames not have the latest file served. Also with deep linking this also points to
old data which users do not like.