### PR TITLE
Cleanup for QOL-7373

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,11 @@ Optional::
     # If False /dataset/{id}/resource/{resource_id}/orig_download/{filename} will be available
     ckanext.s3filestore.use_filename = True
 
+    # To mask the S3 endpoint with your own domain/endpoint when serving URLs to end users.
+    # This endpoint should be capable of serving S3 objects as if it were an actual bucket.
+    # The real S3 endpoint will still be used for uploading files.
+    ckanext.s3filestore.host_name = https://example.com/my-bucket/
+
 
 ------------------------
 Development Installation

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,6 @@ Required::
 
 
     ckanext.s3filestore.aws_bucket_name = a-bucket-to-store-your-stuff
-    ckanext.s3filestore.host_name = host-to-S3-cloud storage 
     ckanext.s3filestore.region_name = region-name
     ckanext.s3filestore.signature_version = signature (s3v4)
 

--- a/ckanext/s3filestore/controller.py
+++ b/ckanext/s3filestore/controller.py
@@ -114,15 +114,17 @@ class S3Controller(base.BaseController):
 
     def uploaded_file_redirect(self, upload_to, filename):
         '''Redirect static file requests to their location on S3.'''
-        host_name = config.get('ckanext.s3filestore.host_name', 'https://s3.' + config.get('ckanext.s3filestore.region_name') + '.amazonaws.com')
-        # Remove last characted if it's a slash
+        host_name = config.get('ckanext.s3filestore.host_name',
+            'https://{bucket_name}.s3.{region_name}.amazonaws.com'.format(
+                bucket_name=config.get('ckanext.s3filestore.aws_bucket_name'),
+                region_name=config.get('ckanext.s3filestore.region_name'))
+        # Remove last character if it's a slash
         if host_name[-1] == '/':
             host_name = host_name[:-1]
         storage_path = S3Uploader.get_storage_path(upload_to)
         filepath = os.path.join(storage_path, filename)
 
-        redirect_url = '{host_name}/{bucket_name}/{filepath}'\
-                          .format(bucket_name=config.get('ckanext.s3filestore.aws_bucket_name'),
-                          filepath=filepath,
+        redirect_url = '{host_name}/{filepath}'\
+                          .format(filepath=filepath,
                           host_name=host_name)
         redirect(redirect_url)

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -27,8 +27,7 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
         required_options = (
             'ckanext.s3filestore.aws_bucket_name',
             'ckanext.s3filestore.region_name',
-            'ckanext.s3filestore.signature_version',
-            'ckanext.s3filestore.host_name'
+            'ckanext.s3filestore.signature_version'
         )
         if not config.get('ckanext.s3filestore.aws_use_ami_role'):
             required_options += ('ckanext.s3filestore.aws_access_key_id',

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -277,16 +277,7 @@ class S3Uploader(BaseS3Uploader):
                      .format(key_path, self.bucket_name))
 
         try:
-            # Small workaround to manage downloading of large files
-            client = self.get_s3_client()
-
-            # check whether the object exists in S3
-            client.head_object(Bucket=self.bucket_name, Key=key_path)
-
-            url = client.generate_presigned_url(ClientMethod='get_object',
-                                                Params={'Bucket': self.bucket_name,
-                                                        'Key': key_path},
-                                                ExpiresIn=60)
+            url = self.get_signed_url_to_key(key_path)
             h.redirect_to(url)
 
 
@@ -464,17 +455,7 @@ class S3ResourceUploader(BaseS3Uploader):
                      .format(key_path, self.bucket_name))
 
         try:
-            # Small workaround to manage downloading of large files
-            # We are using redirect to minio's resource public URL
-            client = self.get_s3_client()
-
-            # check whether the object exists in S3
-            client.head_object(Bucket=self.bucket_name, Key=key_path)
-
-            url = client.generate_presigned_url(ClientMethod='get_object',
-                                                Params={'Bucket': self.bucket_name,
-                                                        'Key': key_path},
-                                                ExpiresIn=60)
+            url = self.get_signed_url_to_key(key_path)
             h.redirect_to(url)
 
         except ClientError as ex:

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -83,21 +83,8 @@ class BaseS3Uploader(object):
 
         bucket = s3.Bucket(bucket_name)
         try:
-            if s3.Bucket(bucket.name) in s3.buckets.all():
-                log.info('Bucket {0} found!'.format(bucket_name))
-
-            else:
-                log.warning(
-                    'Bucket {0} could not be found,\
-                    attempting to create it...'.format(bucket_name))
-                try:
-                    bucket = s3.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={
-                        'LocationConstraint': 'us-east-1'})
-                    log.info(
-                        'Bucket {0} successfully created'.format(bucket_name))
-                except botocore.exceptions.ClientError as e:
-                    log.warning('Could not create bucket {0}: {1}'.format(
-                        bucket_name, str(e)))
+            s3.meta.client.head_bucket(Bucket=bucket_name)
+            log.info('Bucket {0} found!'.format(bucket_name))
         except botocore.exceptions.ClientError as e:
             error_code = e.response['Error']['Code']
             if error_code == '404':

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -63,13 +63,15 @@ class BaseS3Uploader(object):
                                      region_name=self.region)
 
     def get_s3_resource(self):
-        return self.get_s3_session().resource('s3', endpoint_url=self.host_name,
+        return self.get_s3_session().resource('s3',
                                      config=botocore.client.Config(
+                                     s3={'addressing_style': 'virtual'},
                                      signature_version=self.signature))
 
     def get_s3_client(self):
-        return self.get_s3_session().client('s3', endpoint_url=self.host_name,
+        return self.get_s3_session().client('s3',
                                      config=botocore.client.Config(
+                                     s3={'addressing_style': 'virtual'},
                                      signature_version=self.signature))
 
 


### PR DESCRIPTION
- Use 'head' call to check for bucket presence instead of listing all buckets
- Reuse function instead of duplicating code
- Replace deprecated path-addressing style with virtual addressing