### PR TITLE
[QOL-7373] don't truncate signature timestamp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 boto3>=1.14.17
 ckantoolkit>=0.0.4
-freezegun>=0.3.15


### PR DESCRIPTION
- We can only do it by globally monkey-patching the datetime module,
which introduces race conditions where different threads can get
references to different versions of the datetime functions.