### PR TITLE
[QOL-8179] improve handling of non-ASCII characters for S3 metadata

### DIFF
--- a/ckanext/s3filestore/tests/test_uploader.py
+++ b/ckanext/s3filestore/tests/test_uploader.py
@@ -318,7 +318,7 @@ class TestS3ResourceUploader():
         ''' Tests that text fields from the package are passed to S3.
         '''
         dataset = self._test_dataset()
-        dataset.title = dataset.title + '—with em dash'
+        dataset['title'] = dataset['title'] + '—with em dash'
         resource = self._upload_test_resource(dataset)
         uploader = S3ResourceUploader(resource)
 

--- a/ckanext/s3filestore/tests/test_uploader.py
+++ b/ckanext/s3filestore/tests/test_uploader.py
@@ -313,3 +313,14 @@ class TestS3ResourceUploader():
 
         object_metadata = uploader._get_resource_metadata()
         assert_equal(object_metadata['package_id'], dataset['id'])
+
+    def test_encoding_object_metadata_headers(self):
+        ''' Tests that text fields from the package are passed to S3.
+        '''
+        dataset = self._test_dataset()
+        dataset.title = dataset.title + '—with em dash'
+        resource = self._upload_test_resource(dataset)
+        uploader = S3ResourceUploader(resource)
+
+        object_metadata = uploader._get_resource_metadata()
+        assert_equal(object_metadata['package_title'], 'Test Dataset&#8212;with em dash')

--- a/ckanext/s3filestore/tests/test_uploader.py
+++ b/ckanext/s3filestore/tests/test_uploader.py
@@ -320,7 +320,7 @@ class TestS3ResourceUploader():
     def test_encoding_object_metadata_headers(self):
         ''' Tests that text fields from the package are passed to S3.
         '''
-        dataset = self._test_dataset(title=u'Test Dataset—with em dash', author = u'擬製 暗影')
+        dataset = self._test_dataset(title=u'Test Dataset—with em dash', author=u'擬製 暗影')
         resource = self._upload_test_resource(dataset)
         uploader = S3ResourceUploader(resource)
 

--- a/ckanext/s3filestore/tests/test_uploader.py
+++ b/ckanext/s3filestore/tests/test_uploader.py
@@ -149,6 +149,8 @@ class TestS3ResourceUploader():
         return factories.Dataset(
             name="my-dataset",
             private=private,
+            title=title,
+            author=author,
             owner_org=self.organisation['id'])
 
     def _upload_test_resource(self, dataset=None):

--- a/ckanext/s3filestore/tests/test_uploader.py
+++ b/ckanext/s3filestore/tests/test_uploader.py
@@ -143,7 +143,7 @@ class TestS3Uploader():
 @with_setup(_resource_setup_function)
 class TestS3ResourceUploader():
 
-    def _test_dataset(self, private=False):
+    def _test_dataset(self, private=False, title='Test Dataset', author='test'):
         ''' Creates a test dataset.
         '''
         return factories.Dataset(
@@ -318,9 +318,7 @@ class TestS3ResourceUploader():
     def test_encoding_object_metadata_headers(self):
         ''' Tests that text fields from the package are passed to S3.
         '''
-        dataset = self._test_dataset()
-        dataset['title'] = dataset['title'] + u'—with em dash'
-        dataset['author'] = u'擬製 暗影'
+        dataset = self._test_dataset(title='uTest Dataset—with em dash', author = u'擬製 暗影')
         resource = self._upload_test_resource(dataset)
         uploader = S3ResourceUploader(resource)
 

--- a/ckanext/s3filestore/tests/test_uploader.py
+++ b/ckanext/s3filestore/tests/test_uploader.py
@@ -313,6 +313,7 @@ class TestS3ResourceUploader():
 
         object_metadata = uploader._get_resource_metadata()
         assert_equal(object_metadata['package_id'], dataset['id'])
+        assert_false('notes' in object_metadata['package_id'])
 
     def test_encoding_object_metadata_headers(self):
         ''' Tests that text fields from the package are passed to S3.

--- a/ckanext/s3filestore/tests/test_uploader.py
+++ b/ckanext/s3filestore/tests/test_uploader.py
@@ -320,7 +320,7 @@ class TestS3ResourceUploader():
     def test_encoding_object_metadata_headers(self):
         ''' Tests that text fields from the package are passed to S3.
         '''
-        dataset = self._test_dataset(title='uTest Dataset—with em dash', author = u'擬製 暗影')
+        dataset = self._test_dataset(title=u'Test Dataset—with em dash', author = u'擬製 暗影')
         resource = self._upload_test_resource(dataset)
         uploader = S3ResourceUploader(resource)
 

--- a/ckanext/s3filestore/tests/test_uploader.py
+++ b/ckanext/s3filestore/tests/test_uploader.py
@@ -320,8 +320,10 @@ class TestS3ResourceUploader():
         '''
         dataset = self._test_dataset()
         dataset['title'] = dataset['title'] + '—with em dash'
+        dataset['author'] = '擬製 暗影'
         resource = self._upload_test_resource(dataset)
         uploader = S3ResourceUploader(resource)
 
         object_metadata = uploader._get_resource_metadata()
         assert_equal(object_metadata['package_title'], 'Test Dataset&#8212;with em dash')
+        assert_equal(object_metadata['package_author'], '&#25836;&#35069; &#26263;&#24433;')

--- a/ckanext/s3filestore/tests/test_uploader.py
+++ b/ckanext/s3filestore/tests/test_uploader.py
@@ -319,8 +319,8 @@ class TestS3ResourceUploader():
         ''' Tests that text fields from the package are passed to S3.
         '''
         dataset = self._test_dataset()
-        dataset['title'] = dataset['title'] + '—with em dash'
-        dataset['author'] = '擬製 暗影'
+        dataset['title'] = dataset['title'] + u'—with em dash'
+        dataset['author'] = u'擬製 暗影'
         resource = self._upload_test_resource(dataset)
         uploader = S3ResourceUploader(resource)
 

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -642,10 +642,8 @@ class S3ResourceUploader(BaseS3Uploader):
         package = toolkit.get_action('package_show')(
             context={'ignore_auth': True}, data_dict={'id': self.resource['package_id']})
         metadata = {
-            'package_' + field: ensure_ascii(package[field])
-            for field in package.keys()
-            if field != 'notes'
-            and isinstance(package[field], six.string_types)
+            'package_' + field: ensure_ascii(package[field]) for field in package.keys()
+            if field != 'notes' and isinstance(package[field], six.string_types)
         }
         metadata['uploaded_by'] = ensure_ascii(username)
         return metadata

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -643,7 +643,9 @@ class S3ResourceUploader(BaseS3Uploader):
             context={'ignore_auth': True}, data_dict={'id': self.resource['package_id']})
         metadata = {
             'package_' + field: ensure_ascii(package[field])
-            for field in package.keys() if isinstance(package[field], six.string_types)
+            for field in package.keys()
+            if field != 'notes'
+            and isinstance(package[field], six.string_types)
         }
         metadata['uploaded_by'] = ensure_ascii(username)
         return metadata

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -642,7 +642,7 @@ class S3ResourceUploader(BaseS3Uploader):
         package = toolkit.get_action('package_show')(
             context={'ignore_auth': True}, data_dict={'id': self.resource['package_id']})
         metadata = {
-            'package_' + ensure_ascii(field): ensure_ascii(package[field])
+            'package_' + field: ensure_ascii(package[field])
             for field in package.keys() if isinstance(package[field], six.string_types)
         }
         metadata['uploaded_by'] = ensure_ascii(username)

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -65,6 +65,16 @@ def is_path_addressing():
     return False
 
 
+def ensure_ascii(text):
+    """ Returns a version of the specified text that contains
+    only ASCII characters. 'text' should be UTF-8 encoded.
+    Non-ASCII characters may be either stripped or encoded/escaped.
+    """
+    if not isinstance(text, six.text_type):
+        text = six.text_type(text, 'utf-8')
+    return text.encode('ascii', 'xmlcharrefreplace').decode()
+
+
 class S3FileStoreException(Exception):
     pass
 
@@ -632,10 +642,10 @@ class S3ResourceUploader(BaseS3Uploader):
         package = toolkit.get_action('package_show')(
             context={'ignore_auth': True}, data_dict={'id': self.resource['package_id']})
         metadata = {
-            'package_' + field: six.moves.urllib.parse.quote(package[field])
+            'package_' + ensure_ascii(field): ensure_ascii(package[field])
             for field in package.keys() if isinstance(package[field], six.string_types)
         }
-        metadata['uploaded_by'] = six.moves.urllib.parse.quote(username)
+        metadata['uploaded_by'] = ensure_ascii(username)
         return metadata
 
     def delete(self, id, filename=None):


### PR DESCRIPTION
- use string encode function instead of URL encoding
- handle multiple string types properly