### PR TITLE
[QOL-8405] append ETag to unsigned URLs, #59

### DIFF
--- a/ckanext/s3filestore/tests/test_uploader.py
+++ b/ckanext/s3filestore/tests/test_uploader.py
@@ -6,6 +6,7 @@ import mock
 from nose.tools import (assert_equal,
                         assert_true,
                         assert_false,
+                        assert_in,
                         with_setup)
 
 import ckanapi
@@ -250,6 +251,7 @@ class TestS3ResourceUploader():
         url = uploader.get_signed_url_to_key(key)
 
         assert_false(_is_presigned_url(url))
+        assert_in('ETag=', url)
 
     @helpers.change_config('ckanext.s3filestore.acl', 'auto')
     def test_resource_url_signed_for_private_dataset(self):
@@ -276,6 +278,7 @@ class TestS3ResourceUploader():
 
         url = uploader.get_signed_url_to_key(key)
         assert_false(_is_presigned_url(url))
+        assert_in('ETag=', url)
 
         helpers.call_action('package_patch',
                             context={'user': self.sysadmin['name']},
@@ -305,6 +308,7 @@ class TestS3ResourceUploader():
 
         url = uploader.get_signed_url_to_key(key)
         assert_false(_is_presigned_url(url))
+        assert_in('ETag=', url)
 
     def test_assembling_object_metadata_headers(self):
         ''' Tests that text fields from the package are passed to S3.

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -293,7 +293,7 @@ class BaseS3Uploader(object):
             url = URL_HOST.sub(self.download_proxy + '/', url, 1)
 
         if is_public_read:
-            url = url.split('?')[0]
+            url = url.split('?')[0] + '?ETag=' + metadata['ETag']
 
         self._cache_put(key, url)
         return url


### PR DESCRIPTION
- This should ensure that we don't use an outdated cached copy after the resource changes,
by using a unique query string for each unique resource version.