### PR TITLE
[QOL-7545] update string type to fix github #62

### DIFF
--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -235,7 +235,7 @@ class BaseS3Uploader(object):
         May cache results to reduce API calls.
         '''
         acl_key = _get_visibility_cache_key(key)
-        acl = self._cache_get(acl_key)
+        acl = six.text_type(self._cache_get(acl_key))
         if acl == PUBLIC_ACL:
             return True
         if acl == PRIVATE_ACL:

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -94,7 +94,7 @@ def get_s3_session(config):
 
 def _is_presigned_url(url):
     ''' Determines whether a URL represents a presigned S3 URL.'''
-    parts = url.split('?')
+    parts = six.text_type(url).split('?')
     return len(parts) >= 2 and 'Signature=' in parts[1]
 
 

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -125,7 +125,10 @@ class BaseS3Uploader(object):
             return None
         redis_conn = connect_to_redis()
         cache_key = _get_cache_key(key)
-        return six.text_type(redis_conn.get(cache_key))
+        cache_value = redis_conn.get(cache_key)
+        if cache_value is not None:
+            cache_value = six.text_type(cache_value)
+        return cache_value
 
     def _cache_put(self, key, value):
         ''' Set a value in the cache, if enabled, with an appropriate expiry.


### PR DESCRIPTION
- ensure that string to be split is of the same type as the delimeter.
This is particularly relevant when retrieving strings from Redis cache,
which may return byte objects.