### PR TITLE
Add after_update resource notify as a worker job instead (with fallback)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,9 @@ Optional::
     ckanext.s3filestore.signed_url_expiry = 3600
     ckanext.s3filestore.signed_url_cache_window = 1800
 
+    # Queue used by s3 plugin, if not set, default queue is used
+    # i.e.
+    ckanext.s3filestore.queue = bulk
 
 ------------------------
 Development Installation

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -97,10 +97,10 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
 
         visibility_level = 'private' if is_private else 'public-read'
         try:
-            self.enqueue_resource_visibility_update_job(self, visibility_level, pkg_id, pkg_dict)
+            self.enqueue_resource_visibility_update_job(visibility_level, pkg_id, pkg_dict)
         except:
             LOG.debug("after_update: Could not put on queue, doing inline")
-            self.after_update_resource_list_update(self, visibility_level, pkg_id, pkg_dict)
+            self.after_update_resource_list_update(visibility_level, pkg_id, pkg_dict)
 
     def after_update_resource_list_update(self, visibility_level, pkg_id, pkg_dict):
 

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -18,6 +18,7 @@ LOG = logging.getLogger(__name__)
 
 
 class S3FileStorePlugin(plugins.SingletonPlugin):
+
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IConfigurable)
     plugins.implements(plugins.IUploader)
@@ -117,9 +118,11 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
         ckan_ini_filepath = os.path.abspath(toolkit.config['__file__'])
         resources = pkg_dict
         args = [ckan_ini_filepath, visibility_level, resources]
+        # Optional variable, if not set, default queue is used
+        queue = toolkit.config.get('ckanext.s3filestore.queue', None)
         toolkit.enqueue_job(
             s3_afterUpdatePackage, args=args,
-            title="s3_afterUpdatePackage: setting " + visibility_level + " on " + pkg_id)
+            title="s3_afterUpdatePackage: setting " + visibility_level + " on " + pkg_id, queue=queue)
         LOG.debug("enqueue_resource_visibility_update_job: Package %s has been enqueued",
                   pkg_id)
 

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-
+import os
 import logging
 
 from routes.mapper import SubMapper
@@ -97,7 +97,7 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
 
         visibility_level = 'private' if is_private else 'public-read'
         try:
-            self.enqueue_resource_visability_update_job(self, visibility_level, pkg_id, pkg_dict)
+            self.enqueue_resource_visibility_update_job(self, visibility_level, pkg_id, pkg_dict)
         except:
             LOG.debug("after_update: Could not put on queue, doing inline")
             self.after_update_resource_list_update(self, visibility_level, pkg_id, pkg_dict)
@@ -113,17 +113,15 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
                     target_acl=visibility_level)
         LOG.debug("after_update_resource_list_update: Package %s has been updated, notifying resources finished", pkg_id)
 
-    def enqueue_resource_visability_update_job(visibility_level, pkg_id, pkg_dict):
-        from ckan.plugins.toolkit import enqueue_job
+    def enqueue_resource_visibility_update_job(visibility_level, pkg_id, pkg_dict):
         from ckan.plugins.toolkit import config
-        import os
 
         ckan_ini_filepath = os.path.abspath(config['__file__'])
         resources = pkg_dict
         args = [ckan_ini_filepath, visibility_level, resources]
-        enqueue_job(s3_afterUpdatePackage, args=args,
+        toolkit.enqueue_job(s3_afterUpdatePackage, args=args,
                     title="s3_afterUpdatePackage: setting " + visibility_level + " on " + pkg_id)
-        LOG.debug("enqueue_resource_visability_update_job: Package %s has been enqueued",
+        LOG.debug("enqueue_resource_visibility_update_job: Package %s has been enqueued",
                   pkg_id)
 
     # IRoutes

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -98,7 +98,7 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
         visibility_level = 'private' if is_private else 'public-read'
         try:
             self.enqueue_resource_visibility_update_job(visibility_level, pkg_id, pkg_dict)
-        except:
+        except Exception:
             LOG.debug("after_update: Could not put on queue, doing inline")
             self.after_update_resource_list_update(visibility_level, pkg_id, pkg_dict)
 
@@ -114,13 +114,12 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
         LOG.debug("after_update_resource_list_update: Package %s has been updated, notifying resources finished", pkg_id)
 
     def enqueue_resource_visibility_update_job(visibility_level, pkg_id, pkg_dict):
-        from ckan.plugins.toolkit import config
-
-        ckan_ini_filepath = os.path.abspath(config['__file__'])
+        ckan_ini_filepath = os.path.abspath(toolkit.config['__file__'])
         resources = pkg_dict
         args = [ckan_ini_filepath, visibility_level, resources]
-        toolkit.enqueue_job(s3_afterUpdatePackage, args=args,
-                    title="s3_afterUpdatePackage: setting " + visibility_level + " on " + pkg_id)
+        toolkit.enqueue_job(
+            s3_afterUpdatePackage, args=args,
+            title="s3_afterUpdatePackage: setting " + visibility_level + " on " + pkg_id)
         LOG.debug("enqueue_resource_visibility_update_job: Package %s has been enqueued",
                   pkg_id)
 

--- a/ckanext/s3filestore/tasks.py
+++ b/ckanext/s3filestore/tasks.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
 # encoding: utf-8
 
 
 import os
 from ckan import plugins as p
-from ckanext.s3filestore import plugin
 from six.moves.urllib import parse as urlparse
 import routes
 
@@ -25,6 +23,7 @@ def s3_afterUpdatePackage(ckan_ini_filepath, visibility_level, pkg_id, pkg_dict)
     # Also put try/except around it is easier to monitor ckan's log rather than
     # celery's task status.
     try:
+        plugin = p.get_plugin("s3filestore")
         plugin.after_update_resource_list_update(visibility_level, pkg_id, pkg_dict)
     except Exception as e:
         if os.environ.get('DEBUG'):

--- a/ckanext/s3filestore/tasks.py
+++ b/ckanext/s3filestore/tasks.py
@@ -1,27 +1,26 @@
 # encoding: utf-8
 
-
-import os
-from ckan import plugins as p
-from six.moves.urllib import parse as urlparse
-import routes
-
 import logging
+import os
+
+from ckan import plugins as p
+
 toolkit = p.toolkit
-config = toolkit.config
 log = logging.getLogger(__name__)
+
 
 def s3_afterUpdatePackage(ckan_ini_filepath, visibility_level, pkg_id, pkg_dict):
     '''
-       Archive a package.
-       '''
-    load_config(ckan_ini_filepath)
+    Archive a package.
+    '''
+    if ckan_ini_filepath:
+        toolkit.load_config(ckan_ini_filepath)
 
     log.info('Starting s3_afterUpdatePackage task: package_id=%r, visibility_level=%s', pkg_id, visibility_level)
 
-    # Do all work in a sub-routine since it can then be tested without celery.
-    # Also put try/except around it is easier to monitor ckan's log rather than
-    # celery's task status.
+    # Do all work in a sub-routine so it can be tested without a job queue.
+    # Also put try/except around it, as it is easier to monitor CKAN's log
+    # rather than a queue's task status.
     try:
         plugin = p.get_plugin("s3filestore")
         plugin.after_update_resource_list_update(visibility_level, pkg_id, pkg_dict)
@@ -30,16 +29,6 @@ def s3_afterUpdatePackage(ckan_ini_filepath, visibility_level, pkg_id, pkg_dict)
             raise
         # Any problem at all is logged and reraised so that celery can log it
         # too
-        log.error('Error occurred during s3_afterUpdatePackage: %s\nPackage: %s',
-                  e, pkg_id)
+        log.error('Error occurred during s3_afterUpdatePackage of package %s: %s',
+                  pkg_id, e)
         raise
-
-def load_config(ckan_ini_filepath):
-    if ckan_ini_filepath:
-        toolkit.load_config(ckan_ini_filepath)
-
-    # give routes enough information to run url_for
-    parsed = urlparse.urlparse(config.get('ckan.site_url', 'http://0.0.0.0'))
-    request_config = routes.request_config()
-    request_config.host = parsed.netloc + parsed.path
-    request_config.protocol = parsed.scheme

--- a/ckanext/s3filestore/tasks.py
+++ b/ckanext/s3filestore/tasks.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+
+import os
+from ckan import plugins as p
+from ckanext.s3filestore import plugin
+from six.moves.urllib import parse as urlparse
+import routes
+
+import logging
+toolkit = p.toolkit
+config = toolkit.config
+log = logging.getLogger(__name__)
+
+def s3_afterUpdatePackage(ckan_ini_filepath, visibility_level, pkg_id, pkg_dict):
+    '''
+       Archive a package.
+       '''
+    load_config(ckan_ini_filepath)
+
+    log.info('Starting s3_afterUpdatePackage task: package_id=%r, visibility_level=%s', pkg_id, visibility_level)
+
+    # Do all work in a sub-routine since it can then be tested without celery.
+    # Also put try/except around it is easier to monitor ckan's log rather than
+    # celery's task status.
+    try:
+        plugin.after_update_resource_list_update(visibility_level, pkg_id, pkg_dict)
+    except Exception as e:
+        if os.environ.get('DEBUG'):
+            raise
+        # Any problem at all is logged and reraised so that celery can log it
+        # too
+        log.error('Error occurred during s3_afterUpdatePackage: %s\nPackage: %s',
+                  e, pkg_id)
+        raise
+
+def load_config(ckan_ini_filepath):
+    if ckan_ini_filepath:
+        toolkit.load_config(ckan_ini_filepath)
+
+    # give routes enough information to run url_for
+    parsed = urlparse.urlparse(config.get('ckan.site_url', 'http://0.0.0.0'))
+    request_config = routes.request_config()
+    request_config.host = parsed.netloc + parsed.path
+    request_config.protocol = parsed.scheme


### PR DESCRIPTION
As IPackageController after_update is still in a transaction that has not been committed, we also need to remove any delays so we don't hang other processes wanting to touch the package this resource is in, s3 visibility update does not need the transaction to roll back