### PR TITLE
[QOL-8518] handle link resources using placeholder empty FileStorage

### DIFF
--- a/ckanext/s3filestore/tests/test_uploader.py
+++ b/ckanext/s3filestore/tests/test_uploader.py
@@ -1,13 +1,16 @@
 # encoding: utf-8
+
 import datetime
 import io
 import os
+import six
 
 import mock
 from nose.tools import (assert_equal,
                         assert_true,
                         assert_false,
                         assert_in,
+                        assert_not_in,
                         with_setup)
 
 from botocore.exceptions import ClientError
@@ -311,6 +314,43 @@ class TestS3ResourceUploader():
         object_metadata = uploader._get_resource_metadata()
         assert_equal(object_metadata['package_title'], 'Test Dataset&#8212;with em dash')
         assert_equal(object_metadata['package_author'], '&#25836;&#35069; &#26263;&#24433;')
+
+    def test_ignoring_non_uploads(self):
+        ''' Tests that resources not containing an upload are ignored.
+        '''
+        dataset = self._test_dataset()
+        resource = factories.Resource(package_id=dataset['id'], url='https://example.com')
+        uploader = S3ResourceUploader(resource)
+        assert_equal(resource['url'], 'https://example.com')
+        assert_not_in('filename', uploader)
+        assert_not_in('filesize', uploader)
+        with mock.patch('ckanext.s3filestore.uploader.S3ResourceUploader.update_visibility') as mock_update_visibility,\
+                mock.patch('ckanext.s3filestore.uploader.S3ResourceUploader.upload_to_key') as mock_upload_to_key:
+            uploader.upload(resource['id'])
+            mock_upload_to_key.assert_not_called()
+            mock_update_visibility.assert_called_once_with(resource['id'])
+
+    def test_ignoring_blank_uploads(self):
+        ''' Tests that resources containing a zero-length placeholder
+        upload are ignored.
+        '''
+        dataset = self._test_dataset()
+        resource = helpers.call_action(
+            'resource_create',
+            package_id=dataset['id'],
+            upload=FlaskFileStorage(six.BytesIO(b'')),
+            url='https://example.com')
+
+        resource = factories.Resource(package_id=dataset['id'], url='https://example.com')
+        uploader = S3ResourceUploader(resource)
+        assert_equal(resource['url'], 'https://example.com')
+        assert_not_in('filename', uploader)
+        assert_not_in('filesize', uploader)
+        with mock.patch('ckanext.s3filestore.uploader.S3ResourceUploader.update_visibility') as mock_update_visibility,\
+                mock.patch('ckanext.s3filestore.uploader.S3ResourceUploader.upload_to_key') as mock_upload_to_key:
+            uploader.upload(resource['id'])
+            mock_upload_to_key.assert_not_called()
+            mock_update_visibility.assert_called_once_with(resource['id'])
 
     if toolkit.check_ckan_version(max_version='2.8.99'):
 

--- a/ckanext/s3filestore/tests/test_uploader.py
+++ b/ckanext/s3filestore/tests/test_uploader.py
@@ -10,6 +10,7 @@ from nose.tools import (assert_equal,
                         assert_true,
                         assert_false,
                         assert_in,
+                        assert_none,
                         with_setup)
 
 from botocore.exceptions import ClientError
@@ -328,8 +329,8 @@ class TestS3ResourceUploader():
         for resource in resources:
             uploader = S3ResourceUploader(resource)
             assert_equal(resource['url'], 'https://example.com')
-            assert_false(hasattr(uploader, 'filename'), "Uploader should not have filename for resource {}".format(resource))
-            assert_false(hasattr(uploader, 'filesize'), "Uploader should not have filesize for resource {}".format(resource))
+            assert_none(getattr(uploader, 'filename', None))
+            assert_none(getattr(uploader, 'filesize', None))
             with mock.patch('ckanext.s3filestore.uploader.S3ResourceUploader.update_visibility') as mock_update_visibility,\
                     mock.patch('ckanext.s3filestore.uploader.S3ResourceUploader.upload_to_key') as mock_upload_to_key:
                 uploader.upload(resource['id'])

--- a/ckanext/s3filestore/tests/test_uploader.py
+++ b/ckanext/s3filestore/tests/test_uploader.py
@@ -10,7 +10,7 @@ from nose.tools import (assert_equal,
                         assert_true,
                         assert_false,
                         assert_in,
-                        assert_none,
+                        assert_is_none,
                         with_setup)
 
 from botocore.exceptions import ClientError
@@ -329,8 +329,8 @@ class TestS3ResourceUploader():
         for resource in resources:
             uploader = S3ResourceUploader(resource)
             assert_equal(resource['url'], 'https://example.com')
-            assert_none(getattr(uploader, 'filename', None))
-            assert_none(getattr(uploader, 'filesize', None))
+            assert_is_none(getattr(uploader, 'filename', None))
+            assert_is_none(getattr(uploader, 'filesize', None))
             with mock.patch('ckanext.s3filestore.uploader.S3ResourceUploader.update_visibility') as mock_update_visibility,\
                     mock.patch('ckanext.s3filestore.uploader.S3ResourceUploader.upload_to_key') as mock_upload_to_key:
                 uploader.upload(resource['id'])

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -376,7 +376,8 @@ class S3Uploader(BaseS3Uploader):
 
         if not self.storage_path:
             return
-        if isinstance(self.upload_field_storage, ALLOWED_UPLOAD_TYPES):
+        if isinstance(self.upload_field_storage, ALLOWED_UPLOAD_TYPES) \
+                and self.upload_field_storage.filename:
             self.filename = self.upload_field_storage.filename
             if not self.preserve_filename:
                 self.filename = str(datetime.datetime.utcnow()) + self.filename
@@ -530,7 +531,8 @@ class S3ResourceUploader(BaseS3Uploader):
 
         mime = magic.Magic(mime=True)
 
-        if isinstance(upload_field_storage, ALLOWED_UPLOAD_TYPES):
+        if isinstance(upload_field_storage, ALLOWED_UPLOAD_TYPES) \
+                and upload_field_storage.filename:
             self.filesize = 0  # bytes
 
             self.filename = upload_field_storage.filename


### PR DESCRIPTION
- link resources may create a FileStorage object representing a zero-length binary stream, but they should not be treated as uploads