### PR TITLE
Reduce redis mem usage for enqueued items

### DIFF
--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -115,11 +115,11 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
         kwargs = {
             'args': args,
             'title': "s3_afterUpdatePackage: setting " + visibility_level + " on " + pkg_id,
-
         }
         title = "s3_afterUpdatePackage: setting " + visibility_level + " on " + pkg_id
         rq_kwargs = {
             'on_failure': tasks.s3_afterUpdatePackageFailure,
+            'ttl': 24 * 60 * 60, # 24 hour ttl.
             'failure_ttl': 24 * 60 * 60,  # 24hours of 60mins of 60 seconds.
             'title': title
         }
@@ -128,9 +128,8 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
         if queue:
             kwargs['queue'] = queue
 
-        #toolkit.enqueue_job(fn, args=None, kwargs=None, title=None, queue=DEFAULT_QUEUE_NAME,
-        #    rq_kwargs=None)
-        toolkit.enqueue_job(fn=tasks.s3_afterUpdatePackage, args=args, kwargs=kwargs, title=title, rq_kwargs=rq_kwargs)
+        #jobs.enqueue(fn, args=None, kwargs=None, title=None, queue=DEFAULT_QUEUE_NAME, rq_kwargs=None)
+        toolkit.enqueue_job(fn=tasks.s3_afterUpdatePackage, args=args, kwargs=kwargs, title=title, queue=queue, rq_kwargs=rq_kwargs)
         LOG.debug("enqueue_resource_visibility_update_job: Package %s has been enqueued",
                   pkg_id)
 

--- a/ckanext/s3filestore/tasks.py
+++ b/ckanext/s3filestore/tasks.py
@@ -9,12 +9,20 @@ toolkit = p.toolkit
 log = logging.getLogger(__name__)
 
 
-def s3_afterUpdatePackage(ckan_ini_filepath, visibility_level, pkg_id, pkg_dict=None):
+def s3_afterUpdatePackage(ckan_ini_filepath=None, visibility_level=None, pkg_id=None, pkg_dict=None):
+    u'''
+    After Update a package.
+
+    :param string ckan_ini_filepath: Deprecated, will be removed version+1 release so that in situ jobs are not lost.
+
+    :param boolean visibility_level: what visibility should be set
+
+    :param string pkg_id: package id for resources to update
+
+    :param dict pkg_dic: Deprecated, will be removed version+1 release so that in situ jobs are not lost.
+
+    :raises Exception: if job has failure.
     '''
-    Archive a package.
-    '''
-    if ckan_ini_filepath:
-        toolkit.load_config(ckan_ini_filepath)
 
     log.info('Starting s3_afterUpdatePackage task: package_id=%r, visibility_level=%s', pkg_id, visibility_level)
 
@@ -33,6 +41,38 @@ def s3_afterUpdatePackage(ckan_ini_filepath, visibility_level, pkg_id, pkg_dict=
             raise
         # Any problem at all is logged and reraised so that the job queue
         # can log it too
-        log.error('Error s3_afterUpdatePackage task: Error occurred package_id=%r, visibility_level=%s: %s',
+        log.error('Error s3_afterUpdatePackage task: package_id=%r, visibility_level=%s stackTrace: %s',
                   pkg_id, visibility_level, e)
         raise
+
+
+def s3_afterUpdatePackageFailure(*args, **kwargs):
+    u'''
+    After Update a package Failure, notify pagerduty if plugin is installed
+
+    :param list args: List of arguments to be passed to the function.
+
+    :param dict kwargs: Dict of keyword arguments to be passed to the function.
+        Expected Args:
+        'visibility_level'  : boolean, what visability should be set
+        'pkg_id'            : package id for resources to update
+    '''
+
+    log.info('Starting s3_afterUpdatePackageFailure task: package_id=%r, visibility_level=%s', kwargs['pkg_id'], kwargs['visibility_level'])
+
+    # Do all work in a sub-routine so it can be tested without a job queue.
+    # Also put try/except around it, as it is easier to monitor CKAN's log
+    # rather than a queue's task status.
+    try:
+
+        plugin = p.get_plugin("pagerduty_notify")
+        if plugin is None:
+            return
+
+        plugin.notify(*args, **kwargs)
+        log.info('Finished s3_afterUpdatePackageFailure task: package_id=%r, visibility_level=%s', kwargs['pkg_id'], kwargs['visibility_level'])
+
+    except Exception as e:
+        # record in logs, don't raise so it is off queue
+        log.error('Error s3_afterUpdatePackage task: package_id=%r, visibility_level=%s stackTrace: %s',
+                  kwargs['pkg_id'], kwargs['visibility_level'], e)

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -309,7 +309,9 @@ class BaseS3Uploader(object):
 
         if is_public_read:
             #Ensure valid encoded url so newrelic does not complain
-            data = six.ensure_text(urlencode({'ETag': metadata['ETag'].replace("\"", "")}))
+            data = urlencode({'ETag': metadata['ETag'].replace("\"", "")})
+            if hasattr(six, 'ensure_text'):
+                data = six.ensure_text(data)
             url = url.split('?')[0] + '?' + data
 
         self._cache_put(key, url)

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -10,12 +10,14 @@ import os
 import re
 import six
 
+
 import boto3
 from botocore.client import Config
 from botocore.exceptions import ClientError
 import ckantoolkit as toolkit
 import ckan.lib.helpers as h
 from ckan.lib.redis import connect_to_redis
+from six.moves.urllib.parse import urlencode
 
 from ckan.common import g
 from ckan.lib.uploader import ResourceUpload as DefaultResourceUpload, Upload as DefaultUpload
@@ -306,7 +308,9 @@ class BaseS3Uploader(object):
             url = URL_HOST.sub(self.download_proxy + '/', url, 1)
 
         if is_public_read:
-            url = url.split('?')[0] + '?ETag=' + metadata['ETag']
+            #Ensure valid encoded url so newrelic does not complain
+            data = urlencode({'ETag': metadata['ETag'].replace("\"", "")}).encode('utr-8')
+            url = url.split('?')[0] + '?' + data
 
         self._cache_put(key, url)
         return url

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -309,7 +309,7 @@ class BaseS3Uploader(object):
 
         if is_public_read:
             #Ensure valid encoded url so newrelic does not complain
-            data = urlencode({'ETag': metadata['ETag'].replace("\"", "")}).encode('utr-8')
+            data = urlencode({'ETag': metadata['ETag'].replace("\"", "")}).encode('utf-8')
             url = url.split('?')[0] + '?' + data
 
         self._cache_put(key, url)

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -309,7 +309,7 @@ class BaseS3Uploader(object):
 
         if is_public_read:
             #Ensure valid encoded url so newrelic does not complain
-            data = urlencode({'ETag': metadata['ETag'].replace("\"", "")}).encode('utf-8')
+            data = six.ensure_text(urlencode({'ETag': metadata['ETag'].replace("\"", "")}))
             url = url.split('?')[0] + '?' + data
 
         self._cache_put(key, url)


### PR DESCRIPTION
Look up package dict when we come to the enqueued job, not pass it into the queue. With the plugins currently installed, there is way too much metadata attached. Where there was an exception included by another plugin which is not stored in database which is then passed along

Looking at package_show, there is no way to remove other plugin injected data.
https://github.com/ckan/ckan/blob/526886d2c195bac8db555ff5477538d82ab2a2c2/ckan/logic/action/get.py#L937
https://www.data.qld.gov.au/api/action/package_show?id=b4a3f5d5-f3ac-4382-ae93-0c97293c8b69


Improvements we can make also.
Include on_failure function so it does not leave indefinite jobs
https://python-rq.org/docs/
```
* on_failure allows you to run a function after a job fails
* failure_ttl specifies how long failed jobs are kept (defaults to 1 year)
* result_ttl specifies how long (in seconds) successful jobs and their results are kept. Expired jobs will be automatically deleted. Defaults to 500 seconds.
* ttl specifies the maximum queued time (in seconds) of the job before it’s discarded. This argument defaults to None (infinite TTL).
```