### PR TITLE
QOL-8612 fix enqueuing of visibility updates

### DIFF
--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -91,7 +91,7 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
 
         redis = RedisHelper()
         cache_private = redis.get(pkg_id + '/private')
-        redis.put(pkg_id + '/private', is_private_str)
+        redis.put(pkg_id + '/private', is_private_str, expiry=86400)
         # compare current and previous 'private' flags so we know
         # if visibility has changed
         if cache_private is not None and cache_private == is_private_str:

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -105,7 +105,7 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
             try:
                 self.enqueue_resource_visibility_update_job(visibility_level, pkg_id)
             except Exception as e:
-                LOG.debug("after_update: Could not enqueue due to [%s], doing inline", e)
+                LOG.debug("after_update: Failed to enqueue, updating inline. Error: [%s]", e)
                 async_update = False
         if not async_update:
             if 'resources' not in pkg_dict:

--- a/ckanext/s3filestore/tasks.py
+++ b/ckanext/s3filestore/tasks.py
@@ -44,35 +44,3 @@ def s3_afterUpdatePackage(ckan_ini_filepath=None, visibility_level=None, pkg_id=
         log.error('Error s3_afterUpdatePackage task: package_id=%r, visibility_level=%s stackTrace: %s',
                   pkg_id, visibility_level, e)
         raise
-
-
-def s3_afterUpdatePackageFailure(*args, **kwargs):
-    u'''
-    After Update a package Failure, notify pagerduty if plugin is installed
-
-    :param list args: List of arguments to be passed to the function.
-
-    :param dict kwargs: Dict of keyword arguments to be passed to the function.
-        Expected Args:
-        'visibility_level'  : boolean, what visability should be set
-        'pkg_id'            : package id for resources to update
-    '''
-
-    log.info('Starting s3_afterUpdatePackageFailure task: package_id=%r, visibility_level=%s', kwargs['pkg_id'], kwargs['visibility_level'])
-
-    # Do all work in a sub-routine so it can be tested without a job queue.
-    # Also put try/except around it, as it is easier to monitor CKAN's log
-    # rather than a queue's task status.
-    try:
-
-        plugin = p.get_plugin("pagerduty_notify")
-        if plugin is None:
-            return
-
-        plugin.notify(*args, **kwargs)
-        log.info('Finished s3_afterUpdatePackageFailure task: package_id=%r, visibility_level=%s', kwargs['pkg_id'], kwargs['visibility_level'])
-
-    except Exception as e:
-        # record in logs, don't raise so it is off queue
-        log.error('Error s3_afterUpdatePackage task: package_id=%r, visibility_level=%s stackTrace: %s',
-                  kwargs['pkg_id'], kwargs['visibility_level'], e)

--- a/ckanext/s3filestore/tests/test_plugin.py
+++ b/ckanext/s3filestore/tests/test_plugin.py
@@ -3,6 +3,8 @@
 import mock
 from parameterized import parameterized
 
+from ckan.tests import helpers
+
 from ckanext.s3filestore import tasks
 from ckanext.s3filestore.plugin import S3FileStorePlugin
 
@@ -44,6 +46,7 @@ class TestS3Plugin():
                 mock_uploader.update_visibility.assert_called_once_with(
                     'test-resource', target_acl=expected_acl)
 
+    @helpers.change_config('ckan.jobs.timeout', '123')
     def test_enqueueing_visibility_update(self):
         ''' Asynchronous job is created to update object visibility.
         '''
@@ -57,5 +60,6 @@ class TestS3Plugin():
                 func=tasks.s3_afterUpdatePackage,
                 args=[],
                 kwargs={'visibility_level': 'private', 'pkg_id': 'abcde'},
+                timeout=123,
                 ttl=86400
             )

--- a/ckanext/s3filestore/tests/test_plugin.py
+++ b/ckanext/s3filestore/tests/test_plugin.py
@@ -3,6 +3,7 @@
 import mock
 from parameterized import parameterized
 
+from ckanext.s3filestore import tasks
 from ckanext.s3filestore.plugin import S3FileStorePlugin
 
 
@@ -27,7 +28,7 @@ class TestS3Plugin():
         (False, 'public-read')
     ])
     def test_package_after_update(self, is_private, expected_acl):
-        '''S3 object visibility is updated to match package'''
+        ''' S3 object visibility is updated to match package'''
         pkg_dict = {'id': 'test-package',
                     'resources': [{'id': 'test-resource'}]}
         if is_private is not None:
@@ -42,3 +43,19 @@ class TestS3Plugin():
                 self.plugin.after_update({}, pkg_dict)
                 mock_uploader.update_visibility.assert_called_once_with(
                     'test-resource', target_acl=expected_acl)
+
+    def test_enqueueing_visibility_update(self):
+        ''' Asynchronous job is created to update object visibility.
+        '''
+        # ensure that we don't trigger errors
+        self.plugin.enqueue_resource_visibility_update_job('private', 'abcde')
+
+        # check that the args were actually passed in
+        with mock.patch('rq.Queue.enqueue_call') as enqueue_call:
+            self.plugin.enqueue_resource_visibility_update_job('private', 'abcde')
+            enqueue_call.assert_called_once_with(
+                func=tasks.s3_afterUpdatePackage,
+                args=[],
+                kwargs={'visibility_level': 'private', 'pkg_id': 'abcde'},
+                ttl=86400
+            )

--- a/ckanext/s3filestore/tests/test_plugin.py
+++ b/ckanext/s3filestore/tests/test_plugin.py
@@ -70,8 +70,7 @@ class TestS3Plugin():
                         kwargs={'visibility_level': 'private', 'pkg_id': 'abcde'},
                         timeout=DEFAULT_JOB_TIMEOUT,
                         ttl=86400,
-                        failure_ttl=86400,
-                        on_failure=tasks.s3_afterUpdatePackageFailure
+                        failure_ttl=86400
                     )
                 else:
                     enqueue_call.assert_called_once_with(

--- a/ckanext/s3filestore/tests/test_plugin.py
+++ b/ckanext/s3filestore/tests/test_plugin.py
@@ -3,7 +3,7 @@
 import mock
 from parameterized import parameterized
 
-from ckan.tests import helpers
+from ckan.lib.jobs import DEFAULT_JOB_TIMEOUT
 
 from ckanext.s3filestore import tasks
 from ckanext.s3filestore.plugin import S3FileStorePlugin
@@ -46,7 +46,6 @@ class TestS3Plugin():
                 mock_uploader.update_visibility.assert_called_once_with(
                     'test-resource', target_acl=expected_acl)
 
-    @helpers.change_config('ckan.jobs.timeout', '123')
     def test_enqueueing_visibility_update(self):
         ''' Asynchronous job is created to update object visibility.
         '''
@@ -60,6 +59,6 @@ class TestS3Plugin():
                 func=tasks.s3_afterUpdatePackage,
                 args=[],
                 kwargs={'visibility_level': 'private', 'pkg_id': 'abcde'},
-                timeout=123,
+                timeout=DEFAULT_JOB_TIMEOUT,
                 ttl=86400
             )


### PR DESCRIPTION
- use different arguments according to the CKAN version (and associated `rq` version)
- 'title' belongs at the top level, not within `kwargs` or `rq_kwargs`
- don't pass `None` queue names
- add testing to verify that arguments can be passed through without error