### PR TITLE
QOL-8612 fix bugs in migration CLI

### DIFF
--- a/ckanext/s3filestore/cli_commands.py
+++ b/ckanext/s3filestore/cli_commands.py
@@ -112,12 +112,14 @@ class S3FilestoreCommands():
         print('{0} resources matched on the database'.format(
             len(resource_ids_and_names.keys())))
 
-        BASE_PATH = config.get('ckan.storage_path', '/var/lib/ckan/default/resources')
+        BASE_PATH = os.path.join(config.get('ckan.storage_path', '/var/lib/ckan/default/'), 'resources')
         resource_ids_and_paths = {}
         for resource_id in resource_ids_and_names.keys():
-            path = '{}/{}/{}/{}'.format(BASE_PATH, resource_id[0:2], resource_id[3:5], resource[6:])
+            path = '{}/{}/{}/{}'.format(BASE_PATH, resource_id[0:3], resource_id[3:6], resource_id[6:])
             if os.path.isfile(path):
                 resource_ids_and_paths[resource_id] = path
+            else:
+                print("[{}] not found on the file system".format(path))
 
         print('Found {0} resource files in the file system'.format(
             len(resource_ids_and_paths.keys())))

--- a/ckanext/s3filestore/cli_commands.py
+++ b/ckanext/s3filestore/cli_commands.py
@@ -6,9 +6,9 @@ import sys
 
 from sqlalchemy import create_engine
 from sqlalchemy.sql import text
-from ckan.plugins.toolkit import config
+from ckan.lib import munge
+from ckan.plugins.toolkit import config, get_action, ValidationError
 from ckanext.s3filestore import uploader
-from ckan.logic import get_action, ValidationError
 from ckanext.s3filestore.uploader import get_s3_session, S3FileStoreException
 
 
@@ -190,6 +190,7 @@ def _upload_files_to_s3(resource_ids_and_names, resource_ids_and_paths):
     context = {'ignore_auth': True}
     uploaded_resources = []
     for resource_id, file_name in resource_ids_and_names.iteritems():
+        file_name = munge.munge_filename(file_name)
         key = 'resources/{resource_id}/{file_name}'.format(
             resource_id=resource_id, file_name=file_name)
 


### PR DESCRIPTION
- Munge filenames when migrating, to match the behaviour when uploaded via the web interface
- Fix the disk location of files for single resources
- Handle 'auto' ACL values.