### PR TITLE
Correct logic to use IUploader download function or override controllers is not existing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
             ckan-git-version: 'ckan-2.8.8-qgov.5'
             ckan-git-org: 'qld-gov-au'
           - ckan-version: '2.9'
-            ckan-git-version: 'ckan-2.9.5-qgov.9'
+            ckan-git-version: 'ckan-2.9.5-qgov.10'
             ckan-git-org: 'qld-gov-au'
           - ckan-version: '2.9'
-            ckan-git-version: 'ckan-2.9.7-qgov'
+            ckan-git-version: 'qgov-master-2.9.7'
             ckan-git-org: 'qld-gov-au'
 
       fail-fast: false

--- a/ckanext/s3filestore/controller.py
+++ b/ckanext/s3filestore/controller.py
@@ -4,14 +4,17 @@ from ckantoolkit import BaseController
 
 from .views import resource_download, filesystem_resource_download, uploaded_file_redirect
 
+# IRoutes Controller
+# Ignored on CKAN >= 2.9
+
 
 class S3Controller(BaseController):
 
     def resource_download(self, id, resource_id, filename=None):
-        return resource_download(id, resource_id, filename)
+        return resource_download(u"dataset", id, resource_id, filename)
 
     def filesystem_resource_download(self, id, resource_id, filename=None):
-        return filesystem_resource_download(id, resource_id, filename)
+        return filesystem_resource_download(u"dataset", id, resource_id, filename)
 
     def uploaded_file_redirect(self, upload_to, filename):
         return uploaded_file_redirect(upload_to, filename)

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -6,8 +6,9 @@ import six
 from ckan import plugins
 import ckantoolkit as toolkit
 from ckanext.s3filestore import uploader as s3_uploader
-from ckan.lib.uploader import ResourceUpload as DefaultResourceUpload,\
-    get_resource_uploader
+from ckan.lib.uploader import get_resource_uploader, \
+    ResourceUpload as DefaultResourceUpload
+
 
 import ckanext.s3filestore.tasks as tasks
 
@@ -156,8 +157,9 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
         from routes.mapper import SubMapper
 
         with SubMapper(map, controller='ckanext.s3filestore.controller:S3Controller') as m:
-            # Override the resource download links
+            # IUploader interface does not handle download, like qgov version does, override core ckan controllers
             if not hasattr(DefaultResourceUpload, 'download'):
+                # Override the resource download links
                 m.connect('s3_resource.resource_download',
                           '/dataset/{id}/resource/{resource_id}/download',
                           action='resource_download')

--- a/ckanext/s3filestore/tests/test_controller.py
+++ b/ckanext/s3filestore/tests/test_controller.py
@@ -58,6 +58,7 @@ class TestS3Controller(object):
             'resource_create',
             package_id=dataset['id'],
             upload=FlaskFileStorage(io.open(file_path, 'rb')))
+
         return resource
 
     def test_resource_show_url(self):

--- a/ckanext/s3filestore/views/__init__.py
+++ b/ckanext/s3filestore/views/__init__.py
@@ -3,104 +3,84 @@
 import logging
 import os
 
+
 from botocore.exceptions import ClientError
 
 from ckan import model
-from ckan.lib import uploader
+from ckan.common import request
+
+from ckanext.s3filestore import uploader
 from ckan.lib.uploader import ResourceUpload as DefaultResourceUpload
-from ckan.plugins.toolkit import abort, config, _, g, get_action,\
-    NotAuthorized, ObjectNotFound, url_for, redirect_to
+from ckan.plugins.toolkit import abort, _, g, get_action,\
+    NotAuthorized, ObjectNotFound, redirect_to
 
 from ckanext.s3filestore.uploader import S3Uploader, BaseS3Uploader
 
 log = logging.getLogger(__name__)
 
 
-def resource_download(id, resource_id, filename=None):
+def resource_download(package_type, id, resource_id, filename=None):
     '''
     Provide a download by either redirecting the user to the url stored or
     downloading the uploaded file from S3.
     '''
-    context = {'model': model, 'session': model.Session,
-               'user': g.user, 'auth_user_obj': g.userobj}
+    context = {u'model': model,
+               u'session': model.Session,
+               u'user': g.user,
+               u'auth_user_obj': g.userobj}
 
     try:
-        rsc = get_action('resource_show')(context, {'id': resource_id})
+        rsc = get_action(u'resource_show')(context, {'id': resource_id})
+        get_action(u'package_show')(context, {u'id': id})
+
+        if rsc.get('url_type') == 'upload':
+            upload = uploader.S3ResourceUploader(rsc)
+            return upload.download(rsc['id'], filename)
+
+        elif u'url' not in rsc:
+            return abort(404, _(u'No download is available'))
+
+        # if we're trying to download a link resource, just redirect to it
+        return redirect_to(rsc['url'])
     except ObjectNotFound:
-        return abort(404, _('Resource not found'))
+        return abort(404, _(u'Resource not found'))
     except NotAuthorized:
-        return abort(401, _('Unauthorized to read resource %s') % id)
-
-    if 'url' not in rsc:
-        return abort(404, _('No download is available'))
-    elif rsc.get('url_type') == 'upload':
-        upload = uploader.get_resource_uploader(rsc)
-
-        if filename is None:
-            filename = os.path.basename(rsc['url'])
-        key_path = upload.get_path(rsc['id'], filename)
-
-        if filename is None:
-            log.warn("Key '%s' not found in bucket '%s'",
-                     key_path, upload.bucket_name)
-
-        try:
-            url = upload.get_signed_url_to_key(key_path)
-            return redirect_to(url)
-        except ClientError as ex:
-            if ex.response['Error']['Code'] in ['NoSuchKey', '404']:
-                # attempt fallback
-                if config.get(
-                        'ckanext.s3filestore.filesystem_download_fallback',
-                        False):
-                    log.info('Attempting filesystem fallback for resource %s',
-                             resource_id)
-                    url = url_for(
-                        u's3_resource.filesystem_resource_download',
-                        id=id,
-                        resource_id=resource_id,
-                        filename=filename)
-                    return redirect_to(url)
-
-                return abort(404, _('Resource data not found'))
-            else:
-                raise ex
-    # if we're trying to download a link resource, just redirect to it
-    return redirect_to(rsc['url'])
+        return abort(401, _(u'Not authorized to download resource %s') % id)
+    except (IOError, OSError):
+        return abort(404, _('Resource data not found'))
 
 
-def filesystem_resource_download(id, resource_id, filename=None):
+def filesystem_resource_download(package_type, id, resource_id, filename=None):
     """
     Provide a direct download by either redirecting the user to the url
     stored or downloading an uploaded file directly.
     """
-    if hasattr(DefaultResourceUpload, 'download'):
-        context = {'model': model, 'session': model.Session,
-                   'user': g.user, 'auth_user_obj': g.userobj}
+    context = {u'model': model,
+               u'session': model.Session,
+               u'user': g.user,
+               u'auth_user_obj': g.userobj}
 
-        try:
-            rsc = get_action('resource_show')(context, {'id': resource_id})
-        except ObjectNotFound:
-            return abort(404, _('Resource not found'))
-        except NotAuthorized:
-            return abort(401, _('Unauthorised to read resource %s') % resource_id)
+    try:
+        rsc = get_action(u'resource_show')(context, {u'id': resource_id})
+        get_action(u'package_show')(context, {u'id': id})
+
         upload = DefaultResourceUpload(rsc)
-        try:
-            return upload.download(rsc['id'], filename)
-        except (IOError, OSError):
-            # probably file not found
-            return abort(404, _('Resource data not found'))
-    else:
-        try:
-            from ckan.views.resource import download
-            return download('dataset', id, resource_id, filename)
-        except ImportError:
-            # pre-Flask
-            from ckan.controllers.package import PackageController
-            return PackageController().resource_download(id, resource_id, filename)
-        except (IOError, OSError):
-            # probably file not found
-            return abort(404, _('Resource data not found'))
+        if hasattr(DefaultResourceUpload, 'download'):
+            return upload.download(rsc[u'id'], filename)
+        else:
+            # Fall back as IUploader is not updated, this needs to stay aligned to core ckan.
+            filepath = upload.get_path(rsc[u'id'])
+            if hasattr(request, 'call_application'):
+                return _pylons_download(filepath)
+            else:
+                return _flask_download(filepath)
+
+    except ObjectNotFound:
+        return abort(404, _(u'Resource not found'))
+    except NotAuthorized:
+        return abort(401, _(u'Unauthorised to read resource %s') % resource_id)
+    except (IOError, OSError):
+        return abort(404, _(u'Resource data not found'))
 
 
 def uploaded_file_redirect(upload_to, filename):
@@ -112,9 +92,55 @@ def uploaded_file_redirect(upload_to, filename):
     try:
         url = base_uploader.get_signed_url_to_key(filepath)
     except ClientError as ex:
-        if ex.response['Error']['Code'] in ['NoSuchKey', '404']:
-            return abort(404, _('Keys not found on S3'))
+        if ex.response[u'Error'][u'Code'] in [u'NoSuchKey', u'404']:
+            return abort(404, _(u'Keys not found on S3'))
         else:
             raise ex
 
     return redirect_to(url)
+
+
+def _get_package_type(self, id):
+    """
+    Given the id of a package this method will return the type of the
+    package, or 'dataset' if no type is currently set
+    """
+    pkg = model.Package.get(id)
+    if pkg:
+        return pkg.type or 'dataset'
+    return None
+
+
+def _pylons_download(filepath):
+    import paste
+    from pylons import response
+    import mimetypes
+    fileapp = paste.fileapp.FileApp(filepath)
+
+    status, headers, app_iter = request.call_application(fileapp)
+    response.headers.update(dict(headers))
+    content_type, content_enc = mimetypes.guess_type(filepath)
+    _add_download_headers(filepath, content_type, response)
+    response.status = status
+    return app_iter
+
+
+def _flask_download(filepath):
+    import flask
+    import mimetypes
+    resp = flask.send_file(filepath)
+    content_type, content_enc = mimetypes.guess_type(filepath)
+    _add_download_headers(filepath, content_type, resp)
+    return resp
+
+
+def _add_download_headers(file_path, mime_type, response):
+    """ Add appropriate 'Content-Type' and 'Content-Disposition' headers
+    to a a file download.
+    """
+    if mime_type:
+        response.headers['Content-Type'] = mime_type
+    if mime_type != 'application/pdf':
+        file_name = file_path.split('/')[-1]
+        response.headers['Content-Disposition'] = \
+            'attachment; filename=' + file_name

--- a/ckanext/s3filestore/views/resource.py
+++ b/ckanext/s3filestore/views/resource.py
@@ -4,7 +4,8 @@ import logging
 
 import flask
 
-from ckan.plugins.toolkit import config
+from ckan.plugins.toolkit import config, asbool
+from ckan.lib.uploader import ResourceUpload as DefaultResourceUpload
 
 from . import resource_download, filesystem_resource_download
 
@@ -15,18 +16,24 @@ Blueprint = flask.Blueprint
 s3_resource = Blueprint(
     u's3_resource',
     __name__,
-    url_prefix=u'/dataset/<id>/resource'
+    url_prefix=u'/dataset/<id>/resource',
+    url_defaults={u'package_type': u'dataset'}
 )
 
+# IUploader interface does not handle download, like qgov version does, override core ckan controllers
+if not hasattr(DefaultResourceUpload, 'download'):
+    # Override the resource download links
+    s3_resource.add_url_rule(u'/<resource_id>/download',
+                             view_func=resource_download)
+    s3_resource.add_url_rule(u'/<resource_id>/download/<filename>',
+                             view_func=resource_download)
 
-s3_resource.add_url_rule(u'/<resource_id>/download',
-                         view_func=resource_download)
-s3_resource.add_url_rule(u'/<resource_id>/download/<filename>',
-                         view_func=resource_download)
+# fallback controller action to download from the filesystem
 s3_resource.add_url_rule(u'/<resource_id>/fs_download/<filename>',
                          view_func=filesystem_resource_download)
 
-if not config.get('ckanext.s3filestore.use_filename', False):
+# Allow fallback to access old files
+if not asbool(config.get('ckanext.s3filestore.use_filename', False)):
     s3_resource.add_url_rule(
         u'/<resource_id>/orig_download/<filename>', view_func=resource_download
     )

--- a/ckanext/s3filestore/views/uploads.py
+++ b/ckanext/s3filestore/views/uploads.py
@@ -11,7 +11,7 @@ s3_uploads = Blueprint(
     __name__
 )
 
-
+# Intercept the uploaded file links (e.g. group images)
 s3_uploads.add_url_rule(u'/uploads/<upload_to>/<filename>', view_func=uploaded_file_redirect)
 
 


### PR DESCRIPTION
When using qgov ckan, 2.9.5 must be on ckan-2.9.5-qgov.10, https://github.com/qld-gov-au/ckan/releases/tag/ckan-2.9.5-qgov.10 

qgov 2.8.x passes, vanilla ckan 2.7~ 2.9.x passes
