### PR TITLE
QOLDEV-1003 add optional testing of latest CKAN master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,9 @@ jobs:
         continue-on-error: ${{ matrix.experimental }}
         run: ./scripts/test.sh
         timeout-minutes: 30
+
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: "/tmp/artifacts/junit/results.xml"
+        if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
     strategy:
       matrix:
         ckan-version: ['2.11', '2.10', '2.9']
+        experimental: [false]
         ckan-git-org: ['ckan']
         include:
           - ckan-version: '2.9'
@@ -45,6 +46,10 @@ jobs:
           - ckan-version: '2.9'
             ckan-git-version: 'qgov-master-2.9.9'
             ckan-git-org: 'qld-gov-au'
+          - ckan-version: 'master'
+            ckan-git-org: 'ckan'
+            ckan-git-version: 'master'
+            experimental: true  #master is unstable, good to know if we are compatible or not
 
       fail-fast: false
 
@@ -101,17 +106,18 @@ jobs:
         timeout-minutes: 2
 
       - name: Install requirements
+        continue-on-error: ${{ matrix.experimental }}
         run: |
           chmod u+x ./scripts/*
           ./scripts/build.sh
         timeout-minutes: 15
 
       - name: Setup CKAN
-        run: |
-          ./scripts/init.sh
+        continue-on-error: ${{ matrix.experimental }}
+        run: ./scripts/init.sh
         timeout-minutes: 15
 
       - name: Run tests
-        run: |
-          ./scripts/test.sh
+        continue-on-error: ${{ matrix.experimental }}
+        run: ./scripts/test.sh
         timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         timeout-minutes: 2
 
       - name: Install requirements

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -123,6 +123,9 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
 
         LOG.debug("after_update_resource_list_update: Package %s has been updated, notifying resources", pkg_id)
         for resource in pkg_dict['resources']:
+            if 'id' not in resource:
+                # skip new resources as they would already have correct visibility
+                continue
             uploader = get_resource_uploader(resource)
             if hasattr(uploader, 'update_visibility'):
                 uploader.update_visibility(

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-pytest --ckan-ini=test.ini --cov=ckanext.s3filestore
+pytest -vv --ckan-ini=test.ini --cov=ckanext.s3filestore

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-pytest -vv --ckan-ini=test.ini --cov=ckanext.s3filestore
+pytest -vv --ckan-ini=test.ini --cov=ckanext.s3filestore --junit-xml=/tmp/artifacts/junit/results.xml


### PR DESCRIPTION
Add a test run on the latest upstream CKAN master, with success being optional (and tests currently fail), just so we have visibility.