### PR TITLE
Drop 'extras' from recorded metadata since S3 has a size limit

### DIFF
--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -688,6 +688,8 @@ class S3ResourceUploader(BaseS3Uploader):
             if field != 'notes' and isinstance(package[field], six.string_types)
         }
         metadata['uploaded_by'] = ensure_ascii(username)
+        # Drop 'extras' since they risk exceeding the S3 size limit
+        metadata.pop('extras', None)
         return metadata
 
     def delete(self, id, filename=None):


### PR DESCRIPTION
The 'extras' field can easily become very large, issue #132 