### PR TITLE
[QOLSVC-15897] drop synchronous visibility update

### DIFF
--- a/ckanext/s3filestore/tests/test_uploader.py
+++ b/ckanext/s3filestore/tests/test_uploader.py
@@ -162,6 +162,7 @@ class TestS3Uploader():
         return status_code, response.location
 
 
+@helpers.change_config('ckanext.s3filestore.acl.async_update', 'False')
 class TestS3ResourceUploader():
 
     def setup_method(self, test_method):

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -670,7 +670,6 @@ class S3ResourceUploader(BaseS3Uploader):
             filepath = self.get_path(id, self.filename)
             self.upload_to_key(filepath, self.upload_file, acl=self._get_target_acl(id),
                                extra_metadata=self._get_resource_metadata())
-            self.update_visibility(id)
 
         # The resource form only sets self.clear (via the input clear_upload)
         # to True when an uploaded file is not replaced by another uploaded


### PR DESCRIPTION
- We already have a full-dataset visibility update, either synchronous or async, there is no need to run an extra one