### PR TITLE
Develop to master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,22 +29,22 @@ jobs:
       matrix:
         include:
           - ckan-version: '2.12'
-            ckan-git-version: 'dev-v2.12'
+            ckan-git-version: 'ckan-2.12.0'
             ckan-git-org: 'ckan'
             solr-version: 9
             experimental: false
           - ckan-version: '2.11'
-            ckan-git-version: 'ckan-2.11.5'
+            ckan-git-version: 'ckan-2.11.6'
             ckan-git-org: 'ckan'
             solr-version: 9
             experimental: false
           - ckan-version: '2.11'
-            ckan-git-version: 'ckan-2.11.5-qgov.2'
+            ckan-git-version: 'ckan-2.11.6-qgov.1'
             ckan-git-org: 'qld-gov-au'
             solr-version: 9
             experimental: false
           - ckan-version: '2.10'
-            ckan-git-version: 'ckan-2.10.7'
+            ckan-git-version: 'ckan-2.10.10'
             ckan-git-org: 'ckan'
             solr-version: 8
             experimental: false

--- a/README.rst
+++ b/README.rst
@@ -142,7 +142,7 @@ Optional::
     ckanext.s3filestore.public_url_cache_window = 86400
 
     # Control how long the ACL of an S3 object will be held in cache.
-    # Uploading a new file overrides this. Default is 86400 (24 hours).
+    # Uploading a new file overrides this. Default is 604800 (1 week).
     ckanext.s3filestore.acl_cache_window = 2592000
 
     # If set, then prior objects uploaded not matching current filename for a

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -153,7 +153,7 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
         """
         Ensure that we have cached the resource visibility if needed.
         """
-        if 'upload' in resource:
+        if current['url_type'] == 'upload' and 'upload' in resource:
             uploader = s3_uploader.S3ResourceUploader(current)
             uploader.is_key_public(uploader.get_path(current['id']))
 

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -155,7 +155,11 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
         """
         if current['url_type'] == 'upload' and 'upload' in resource:
             uploader = s3_uploader.S3ResourceUploader(current)
-            uploader.is_key_public(uploader.get_path(current['id']))
+            try:
+                uploader.is_key_public(uploader.get_path(current['id']))
+            except Exception:
+                # if we can't update the cache, then we don't need it.
+                pass
 
     def before_resource_delete(self, context, resource_id_dict, resources):
         """

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -149,6 +149,14 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
 
     # IResourceController
 
+    def before_resource_update(self, context, current, resource):
+        """
+        Ensure that we have cached the resource visibility if needed.
+        """
+        if 'upload' in resource:
+            uploader = s3_uploader.S3ResourceUploader(current)
+            uploader.is_key_public(uploader.get_path(current['id']))
+
     def before_resource_delete(self, context, resource_id_dict, resources):
         """
         Delete the stored file from S3 when the CKAN resource is deleted.

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -215,7 +215,7 @@ class BaseS3Uploader(object):
         except Exception as e:
             raise e
 
-    def is_key_public(self, key):
+    def is_key_public(self, key, default=None):
         ''' Check whether an S3 object key is publicly readable.
         May cache results to reduce API calls.
         '''
@@ -225,6 +225,8 @@ class BaseS3Uploader(object):
             return True
         if acl == PRIVATE_ACL:
             return False
+        if default is not None:
+            return default
 
         client = self.get_s3_client()
         # check if the object ACL grants any permission to all users
@@ -647,9 +649,11 @@ class S3ResourceUploader(BaseS3Uploader):
             else:
                 acl = self.non_current_acl
 
-            is_public_read = self.is_key_public(upload_key)
+            is_public_target = acl == PUBLIC_ACL
+            # treat an expired cache for non-current objects as being 'already satisfied'
+            is_public_read = self.is_key_public(upload_key, (upload_key == current_key) != is_public_target)
             # if the ACL status doesn't match what we want, update it
-            if (acl == PUBLIC_ACL) != is_public_read:
+            if is_public_target != is_public_read:
                 log.debug("Updating ACL for object %s to %s", upload_key, acl)
                 client.put_object_acl(
                     Bucket=self.bucket_name, Key=upload_key, ACL=acl)

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -105,7 +105,7 @@ class BaseS3Uploader(object):
         self.signed_url_expiry = int(config.get('ckanext.s3filestore.signed_url_expiry', '3600'))
         self.signed_url_cache_window = int(config.get('ckanext.s3filestore.signed_url_cache_window', '1800'))
         self.public_url_cache_window = int(config.get('ckanext.s3filestore.public_url_cache_window', '86400'))
-        self.acl_cache_window = int(config.get('ckanext.s3filestore.acl_cache_window', '86400'))
+        self.acl_cache_window = int(config.get('ckanext.s3filestore.acl_cache_window', '604800'))
         self.acl = config.get('ckanext.s3filestore.acl', PUBLIC_ACL)
         self.non_current_acl = config.get('ckanext.s3filestore.non_current_acl', PRIVATE_ACL)
         self.addressing_style = config.get('ckanext.s3filestore.addressing_style', 'auto')
@@ -619,9 +619,10 @@ class S3ResourceUploader(BaseS3Uploader):
         client = self.get_s3_client()
 
         current_key = self.get_path(id)
-        all_visibility = self.redis.get(current_key + VISIBILITY_CACHE_PATH + '/all')
-        if all_visibility is not None and all_visibility == target_acl:
+        all_visibility_key = current_key + VISIBILITY_CACHE_PATH + '/all'
+        if self.redis.get(all_visibility_key) == target_acl:
             log.debug("update_visibility: id: %s already set and found in cache as %s", id, target_acl)
+            self.redis.put(all_visibility_key, target_acl, expiry=self.acl_cache_window)
             return
         # iterate through every S3 object matching the resource ID
         log.debug("update_visibility: id: %s getting item list from store", id)
@@ -655,7 +656,7 @@ class S3ResourceUploader(BaseS3Uploader):
                 # Drop the cached URL since it will likely need to change
                 self.redis.delete(upload_key)
                 self.redis.put(upload_key + VISIBILITY_CACHE_PATH, acl, expiry=self.acl_cache_window)
-        self.redis.put(current_key + VISIBILITY_CACHE_PATH + '/all', target_acl, expiry=self.acl_cache_window)
+        self.redis.put(all_visibility_key, target_acl, expiry=self.acl_cache_window)
 
     def upload(self, id, max_size=10):
         '''Upload the file to S3.'''

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -624,7 +624,6 @@ class S3ResourceUploader(BaseS3Uploader):
         all_visibility_key = current_key + VISIBILITY_CACHE_PATH + '/all'
         if self.redis.get(all_visibility_key) == target_acl:
             log.debug("update_visibility: id: %s already set and found in cache as %s", id, target_acl)
-            self.redis.put(all_visibility_key, target_acl, expiry=self.acl_cache_window)
             return
         # iterate through every S3 object matching the resource ID
         log.debug("update_visibility: id: %s getting item list from store", id)


### PR DESCRIPTION
- Extend default caching of dataset and resource visibility to one week.
- Treat expired resource visibility cache as "no action required".
- Prime resource visibility cache before updating a resource, so that we can definitely act on the previous revision.
